### PR TITLE
PNRG seeding improvement

### DIFF
--- a/libraries/uBitcoin/src/utility/trezor/rand.c
+++ b/libraries/uBitcoin/src/utility/trezor/rand.c
@@ -23,33 +23,111 @@
 
 #include "rand.h"
 #include "sha2.h"
+#include <stdio.h>
 #include <string.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <stdbool.h>
 
 // #ifndef RAND_PLATFORM_INDEPENDENT
+
+#pragma message( \
+    "!!! WARNING !!! NOT SUITABLE FOR PRODUCTION USE! Replace init_ram_seed() and random32() functions with your own secure code.")
 
 static uint32_t seed = 0;
 static uint8_t hash[32];
 
+#define UNINITIALIZED_ENTROPY_SIZE 1024
+
+static bool is_zero_filled(uint8_t * buf)
+{
+    int i=0;
+    int res_cmp=0;
+    uint8_t * initialized_heap = (uint8_t *)calloc(1, UNINITIALIZED_ENTROPY_SIZE);
+	if (initialized_heap == NULL) {
+		return true;
+	}
+	
+    res_cmp = memcmp(initialized_heap, buf, UNINITIALIZED_ENTROPY_SIZE);
+    
+    free(initialized_heap);
+    
+    if (res_cmp == 0) {
+        return true;
+    }
+    return false;
+}
+
+static bool is_pattern_filled(uint32_t * buf)
+{
+    int i=0;
+    uint32_t pattern = buf[0];
+    for (i=0; i<UNINITIALIZED_ENTROPY_SIZE/sizeof(uint32_t); i++)
+    {
+        if (buf[i] != pattern) {
+            return false;
+        }
+    }
+    return true;
+}
+
 /* 
- * On boot there is random some device-dependent junk in the RAM
- * It may depend on the platform, but in most cases it can be used
- * to get some device-specific randomness.
- * This is a junky-code that may be not perfect
- * but works much better than normal non-cryptographic PRNGs
+ * !!! WARNING !!!
+ * The following code is used to generate the initial seed.
+ * This code is very far from being cryptographically secure,
+ * and it is not suitable for production use.
+ * Replace init_ram_seed() and random32() with a TRNG if possible.
+ * 
+ * Current seeding mechanism:
+ * SHA256(Uninitialized heap | Uninitialized stack)
  * 
  * Replace the random32() function with your own secure code.
  * There is also a possibility to replace the random_buffer() function 
  * as it is defined as a weak symbol.
  */
 
-static void init_ram_seed(){
-	uint8_t * arr = (uint8_t *)malloc(1000); // just allocate some memory
-	if(arr == NULL){
-		return;
+static void init_ram_seed() {
+	// obtain some entropy from uninitialized stack memory
+	// use only the second 1024 bytes as stack entropy
+	// we use the first 1024 to store heap entropy
+	uint8_t uninitialized_stack[2*UNINITIALIZED_ENTROPY_SIZE];
+	uint8_t * uninitialized_stack_entropy = &uninitialized_stack[UNINITIALIZED_ENTROPY_SIZE];
+	
+	// obtain some entropy from uninitialized heap memory
+	uint8_t * uninitialized_heap = (uint8_t *)malloc(UNINITIALIZED_ENTROPY_SIZE);
+	if (uninitialized_heap == NULL) {
+		while(1){}; // non recoverable error
 	}
-	memcpy(arr, hash, 32); // to maintain previous entropy, kinda
-	sha256_Raw(arr, 1000, hash);
-	free(arr);
+	
+	// fail if stack or heap are zero-filled
+	if (is_zero_filled(uninitialized_stack_entropy)) {
+	    //printf("FAIL: Uninitialized stack is zero-filled\n");
+	    while(1){}; // non recoverable error
+	}
+	if (is_zero_filled(uninitialized_heap)) {
+	    //printf("FAIL: Uninitialized heap is zero-filled\n");
+	    while(1){}; // non recoverable error
+	}
+	
+	// fail if stack or heap are 32bit pattern-filled
+	if (is_pattern_filled((uint32_t *)uninitialized_stack_entropy)) {
+	    //printf("FAIL: Uninitialized stack is pattern-filled\n");
+	    while(1){}; // non recoverable error
+	}
+	if (is_pattern_filled((uint32_t *)uninitialized_heap)) {
+	    //printf("FAIL: Uninitialized heap is pattern-filled\n");
+	    while(1){}; // non recoverable error
+	}
+	
+	// SHA256(Uninitialized heap | Uninitialized stack)
+	memcpy(uninitialized_stack, uninitialized_heap, UNINITIALIZED_ENTROPY_SIZE);
+	sha256_Raw(uninitialized_stack, sizeof(uninitialized_stack), hash);
+	
+	// clean entropy source so it cannot be recostructed
+	memset(uninitialized_stack, 0, sizeof(uninitialized_stack));
+	memset(uninitialized_heap, 0, UNINITIALIZED_ENTROPY_SIZE);
+	
+	free(uninitialized_heap);
 	seed++;
 }
 


### PR DESCRIPTION
The purpose of this commit is:
1) warn users with pragma message to avoid using those functions in production
2) add uninitialized stack (together as the previous uninitialized heap) as extra entropy source (because while testing some embedded devices the heap allocations are often zero-filled and I was often getting the same private keys, so the current implementation is EXTREMELY unsafe)
3) double check if heap and stack are truly uninitialized (zero-fill and pattern checks), some compilers might initialized stack variables automatically (e.g. Clang with -ftrivial-auto-var-init), so fail seed initialization in that case.
4) is seeding fails, loop forever, do not generate any random

Seed init is still garbage and a TRNG should be used, but at least it's a (tiny) bit less unsafe.

About the old line:
  memcpy(arr, hash, 32); // to maintain previous entropy, kinda
This doesn't make any sense, since
  static uint8_t hash[32];
will be always inizialized to zero, so this memcpy only zero-fills the first 32 bytes which obviously reduces the entropy and it's pretty much useless and I removed it.